### PR TITLE
Fix typo in Punycode.podspec

### DIFF
--- a/Punycode.podspec
+++ b/Punycode.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   s.name                   = "Punycode"
   s.version                = "1.0.0"
-  s.summary                = "A Pure Swift library for encod and decode punycoded strings supporting iOS, macOS, and tvOS."
+  s.summary                = "A Pure Swift library for encode and decode punycoded strings supporting iOS, macOS, and tvOS."
   s.homepage               = "https://github.com/gumob/PunycodeSwift"
   s.license                = { :type => "MIT", :file => "LICENSE" }
   s.author                 = { "gumob" => "hello@gumob.com" }


### PR DESCRIPTION
Fix typo: `encod` to `encode`