### PR TITLE
Set the flag to allow app extension only

### DIFF
--- a/Punycode.xcodeproj/project.pbxproj
+++ b/Punycode.xcodeproj/project.pbxproj
@@ -600,6 +600,7 @@
 		A7A0ECF2219EB279004FBE05 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
@@ -628,6 +629,7 @@
 		A7A0ECF3219EB279004FBE05 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
It's a pretty simple change.  Just sets the flag in Xcode.  This removes warnings if using this in a codebase with frameworks and/or app extensions. 