### PR TITLE
Fix Fatal error: Can't remove items from an empty collection

### DIFF
--- a/Source/Punycode.swift
+++ b/Source/Punycode.swift
@@ -86,7 +86,7 @@ public class Punycode {
             let oldI: Int = i
             var w: Int = 1
             var k: Int = base
-            while true {
+            repeat {
                 let character: Character = punycodeInput.removeFirst()
                 guard let digit: Int = punycodeIndex(for: character) else {
                     return nil    /// Failing on badly formatted punycode
@@ -98,7 +98,7 @@ public class Punycode {
                 }
                 w *= base - t
                 k += base
-            }
+            } while !punycodeInput.isEmpty
             bias = adaptBias(i - oldI, output.count + 1, oldI == 0)
             n += i / (output.count + 1)
             i %= (output.count + 1)

--- a/Tests/PunycodeTests.swift
+++ b/Tests/PunycodeTests.swift
@@ -109,6 +109,11 @@ final class PunycodeTests: XCTestCase {
         XCTAssert(idnaCode.idnaDecoded == idna)
     }
 
+    func testInvalidPunycodeIsNotFatal() {
+        let invalidPunycode: String = "xn--g"
+        XCTAssertNoThrow(invalidPunycode.idnaDecoded)
+    }
+
 //    func testFoo1() {
 //        var sushi: String = "寿司"
 //


### PR DESCRIPTION
**Problem:**
Inputting invalid punycode into `decodePunycode(_)` sometimes produces a fatal error on line 90 of `Punycode.swift` when `punycodeInput.removeFirst()` is called. The error output is "Fatal error: Can't remove items from an empty collection". 

Usage of `removeFirst()` on a collection requires that the collection is not empty. See https://developer.apple.com/documentation/swift/array/2884646-removefirst

**Steps to Reproduce:**
- Try decoding invalid punycode strings such as "xn--b", "xn--c" or "xn--g" by calling string.idnaDecoded
- See that a fatal error occurs on line 90 of Punycode.swift

**Solution:**
The outer while loop (beginning on line 85) includes a `!punycodeInput.isEmpty` check, however the inner while loop does not. The inner loop is where the `punycodeInput` actually gets mutated, so this loop requires the isEmpty check.

The `while true {}` loop where the `punycodeInput` substring gets mutated was updated to be a `repeat{}while` loop, with a `!punycodeInput.isEmpty` condition to continue.
 

