### PR TITLE
Release/v2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  swiftlint:
+    runs-on: ghcr.io/cirruslabs/macos-runner:sonoma
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cirruslabs/swiftlint-action@v1
+        with:
+          version: latest
+
   spm:
     name: Swift ${{ matrix.swift }}
     runs-on: macos-14
@@ -96,7 +104,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Run SwiftLint and Build Carthage for ${{ matrix.platform }}
         run: |
-          swiftlint
           carthage build \
             --no-skip-current \
             --platform ${{ matrix.platform }} \


### PR DESCRIPTION
- Introduce a new job called 'swiftlint' that runs on the macOS runner
   - Install swiftlint using the cirruslabs/swiftlint-action@v1 action
   - Run swiftlint to check for code style violations
   - Remove the manual call to 'swiftlint' from the 'spm' job's run script, as it is now handled by the new 'swiftlint' job