### PR TITLE
Release/v2.2.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,9 +7,12 @@ disabled_rules:
 line_length: 480
 function_body_length: 100
 
-included:
-  - Source/**/*.swift
-  - Tests/**/*.swift
+identifier_name:
+  excluded:
+    - id
+    - ok
 
 excluded:
-  - ./**
+  - Carthage
+  - Pods
+  - fastlane


### PR DESCRIPTION
refactor(.swiftlint.yml): Update excluded rules to ignore Carthage, Pods, and fastlane directories