### PR TITLE
Release/v2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,13 @@ jobs:
       - name: ${{ matrix.name }}
         run: |-
           set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Punycode.xcodeproj" -scheme "Punycode-macOS" -destination "platform=macOS" -enableCodeCoverage ${{ matrix.coverage }} clean test | ${{ matrix.outputFilter }}
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.coverage == 'YES' }}
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
     needs: swiftlint
 
   # test_Catalyst:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,26 +64,30 @@ jobs:
             name: "Test: macOS 14, Xcode 15.4, Swift 5.10"
             testPlan: "macOS"
             outputFilter: xcbeautify --renderer github-actions
+            coverage: YES
           - xcode: "Xcode_15.2"
             runsOn: macos-14
             name: "Test: macOS 14, Xcode 15.2, Swift 5.9.2"
             testPlan: "macOS"
             outputFilter: xcbeautify --renderer github-actions
+            coverage: NO
           - xcode: "Xcode_14.3.1"
             runsOn: macOS-13
             name: "Test: macOS 13, Xcode 14.3.1, Swift 5.8.0"
             testPlan: "macOS"
             outputFilter: xcbeautify --renderer github-actions
+            coverage: NO
           - xcode: "Xcode_14.2"
             runsOn: macOS-12
             name: "Test: macOS 12, Xcode 14.2, Swift 5.7.2"
             testPlan: "macOS"
             outputFilter: xcpretty
+            coverage: NO
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
         run: |-
-          set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Punycode.xcodeproj" -scheme "Punycode-macOS" -destination "platform=macOS" clean test | ${{ matrix.outputFilter }}
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Punycode.xcodeproj" -scheme "Punycode-macOS" -destination "platform=macOS" -enableCodeCoverage ${{ matrix.coverage }} clean test | ${{ matrix.outputFilter }}
     needs: swiftlint
 
   # test_Catalyst:


### PR DESCRIPTION
This commit adds a new step in the main workflow to upload code coverage reports to Codecov when running tests on macOS. The change is intended to improve the quality of the project's code coverage reporting and make it easier to track test coverage over time.