### PR TITLE
Release/v2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,6 +247,7 @@ jobs:
       - name: Test SPM
         run: swift test -c debug 2>&1 | ${{ matrix.outputFilter }}
     needs: [test_macOS, test_iOS, test_tvOS]
+    # needs: [test_macOS, test_iOS, test_tvOS, test_visionOS, test_watchOS, test_Catalyst]
 
   carthage:
     runs-on: macos-14


### PR DESCRIPTION
Previously, the Test SPM job only ran on macOS, iOS, and tvOS. This commit adds support for running the test on visionOS, watchOS, and Catalyst as well. The change was made to improve the comprehensive testing of our project across multiple platforms.