### PR TITLE
Punycode 4.0.0: manifest modernization, Linux support, decode hardening, URL-aware IDNA API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,17 @@ jobs:
         run: swift test -c debug 2>&1 | xcbeautify --renderer github-actions
     needs: [test_macOS, test_Catalyst, test_simulators]
 
+  SPM_linux:
+    name: "SPM: Linux, Swift 6.2"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container: swift:6.2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test SPM
+        run: swift test -c debug
+    needs: [test_macOS, test_Catalyst, test_simulators]
+
   ### Carthage builds are no longer verified by CI (Carthage is in maintenance mode;
   ### compatibility is kept on a best-effort basis via the Xcode project).
   ### CocoaPods linting is reduced to macOS/iOS Release: the trunk becomes read-only
@@ -203,7 +214,7 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint_code, test_macOS, test_Catalyst, test_simulators, SPM, lint_cocoapods]
+    needs: [lint_code, test_macOS, test_Catalyst, test_simulators, SPM, SPM_linux, lint_cocoapods]
     steps:
       - name: Check all jobs succeeded
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking**: `Package.swift` requires swift-tools 5.9 (Xcode 15 or later for SPM consumers) and declares explicit platforms: macOS 10.13, iOS 12, tvOS 12, watchOS 4, visionOS 1.
-- Product bundle identifiers renamed from `com.gumob.*` to `com.futamura.*`, completing the account rename.
+- Product bundle identifiers renamed from `com.gumob.*` to `dev.futamura.*`, completing the account rename.
 - CI runs on pushes and pull requests to `main` and `develop`, on current macOS runner images, resolving simulator destinations at runtime.
 - API documentation migrated from jazzy to DocC, built and deployed to GitHub Pages by CI; the generated site is no longer tracked in the repository. New URL: <https://futamura.github.io/PunycodeSwift/documentation/punycode/>.
 - Releasing is now a separate tag-triggered workflow that verifies the tag against the project version before publishing. Version tags are immutable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Releasing is now a separate tag-triggered workflow that verifies the tag against the project version before publishing. Version tags are immutable.
 - Development tooling: Ruby 3.4 / Bundler 2.7, gems updated to clear all outstanding Dependabot alerts.
 
+### Fixed
+
+- `punycodeDecoded` returned garbage characters for malformed input instead of nil: inputs ending mid-digit-sequence (e.g. `"y-z"`) and inputs decoding to C1 control characters (e.g. `"abcd"`) now return nil ([#78](https://github.com/futamura/PunycodeSwift/issues/78)).
+- `punycodeDecoded` / `punycodeEncoded` could crash on adversarial input due to unchecked integer overflow; the RFC 3492 overflow checks are now implemented and such inputs return nil ([#78](https://github.com/futamura/PunycodeSwift/issues/78)).
+- `idnaDecoded` now accepts an uppercase `XN--` ACE prefix (RFC 5890 defines it as case-insensitive).
+
+### Changed
+
+- **Breaking**: `idnaEncoded` now maps the hostname before encoding — NFKC compatibility folding (full-width forms, alternate dots), lowercasing, and NFC — so inputs like `"ＧＯＯ．ＧＬ"` encode to `"goo.gl"` ([#4](https://github.com/futamura/PunycodeSwift/issues/4)). The full UTS #46 mapping table is intentionally not implemented. `punycodeEncoded` remains the raw RFC 3492 single-label transformation, now documented as such.
+
 ### Deprecated
 
 - CocoaPods distribution ends when the trunk becomes read-only on 2026-12-02. Migrate to Swift Package Manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `idnaEncodedURL` / `idnaDecodedURL` on `String` and `Substring`: URL-aware variants that transform only the host of a URL-shaped string (`[scheme://][userinfo@]host[:port][/path?query#fragment]`), leaving every other component unchanged. Use these instead of applying `idnaEncoded` to a full URL.
 - Linux support, verified by CI (`swift build` / `swift test` on the official Swift container).
 - GitHub Releases are now created automatically when a version tag is pushed.
 - `CI Success` aggregate check for branch protection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Linux support, verified by CI (`swift build` / `swift test` on the official Swift container).
 - GitHub Releases are now created automatically when a version tag is pushed.
 - `CI Success` aggregate check for branch protection.
 - Community files: `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, issue and PR templates.
 
 ### Changed
 
+- **Breaking**: `Package.swift` requires swift-tools 5.9 (Xcode 15 or later for SPM consumers) and declares explicit platforms: macOS 10.13, iOS 12, tvOS 12, watchOS 4, visionOS 1.
+- Product bundle identifiers renamed from `com.gumob.*` to `com.futamura.*`, completing the account rename.
 - CI runs on pushes and pull requests to `main` and `develop`, on current macOS runner images, resolving simulator destinations at runtime.
 - API documentation migrated from jazzy to DocC, built and deployed to GitHub Pages by CI; the generated site is no longer tracked in the repository. New URL: <https://futamura.github.io/PunycodeSwift/documentation/punycode/>.
 - Releasing is now a separate tag-triggered workflow that verifies the tag against the project version before publishing. Version tags are immutable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.0.0] - 2026-08-18
 
 ### Added
 
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release: Punycode (RFC 3492) encode/decode and IDNA encode/decode via `String` / `Substring` extensions.
 
-[Unreleased]: https://github.com/futamura/PunycodeSwift/compare/3.0.0...HEAD
+[4.0.0]: https://github.com/futamura/PunycodeSwift/compare/3.0.0...4.0.0
 [3.0.0]: https://github.com/futamura/PunycodeSwift/compare/2.1.1...3.0.0
 [2.1.1]: https://github.com/futamura/PunycodeSwift/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/futamura/PunycodeSwift/compare/2.0.0...2.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-PunycodeSwift — a pure Swift library (no dependencies) that encodes/decodes Punycode (RFC 3492) and IDNA hostnames via `String` / `Substring` extensions. Distributed primarily via SPM. Carthage compatibility is best-effort (not CI-verified); CocoaPods distribution (pod name: `Punycode`) ends when the trunk becomes read-only on 2026-12-02.
+PunycodeSwift — a pure Swift library (no dependencies) that encodes/decodes Punycode (RFC 3492) and IDNA hostnames via `String` / `Substring` extensions. Runs on all Apple platforms and Linux. Distributed primarily via SPM. Carthage compatibility is best-effort (not CI-verified); CocoaPods distribution (pod name: `Punycode`) ends when the trunk becomes read-only on 2026-12-02.
 
 ## Commands
 
@@ -53,7 +53,7 @@ Tests live in `Tests/PunycodeTests.swift` (single XCTest file; SPM test target n
 
 - Single source of truth for the version: `MARKETING_VERSION` in `Punycode.xcodeproj/project.pbxproj`. Fastlane and CI both read it. Never edit versions by hand — use `fastlane set_version` / `bump_version`, which also sync `Punycode.podspec`.
 - Branch flow: work on `develop`, PR into `main`.
-- CI (`.github/workflows/main.yml`) runs on push and pull request to `main`/`develop`: lint → per-platform xcodebuild tests (simulator devices resolved at runtime via `simctl`) → SPM → pod lib lint. It does not release. Carthage builds are not CI-verified.
+- CI (`.github/workflows/main.yml`) runs on push and pull request to `main`/`develop`: lint → per-platform xcodebuild tests (simulator devices resolved at runtime via `simctl`) → SPM (macOS + Linux via the official Swift container) → pod lib lint. It does not release. Carthage builds are not CI-verified.
 - Documentation (`.github/workflows/docs.yml`) builds the DocC site with `scripts/gen_docs.sh` (symbolgraph-extract with `-emit-extension-block-symbols` — required because the whole public API is extensions on String/Substring — then `docc convert`) and deploys it to GitHub Pages on every push to `main`. The site is not tracked in git; `docs/` no longer exists.
 - After 2026-12-02 (CocoaPods trunk read-only): remove the `lint_cocoapods` job from `main.yml` and the pod push from `release.yml`.
 - Releasing is a separate, explicit step: push a bare version tag (e.g. `3.0.1`) matching `MARKETING_VERSION`. `.github/workflows/release.yml` then verifies the tag against the project version, creates a GitHub Release (notes taken from the tag's `CHANGELOG.md` section, falling back to generated notes), and pushes to CocoaPods trunk. Use `./run.sh` → "Github - Update tag" to create the tag.

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,17 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Punycode",
+    platforms: [
+        .macOS(.v10_13),
+        .iOS(.v12),
+        .tvOS(.v12),
+        .watchOS(.v4),
+        .visionOS(.v1),
+    ],
     products: [
         .library(
             name: "Punycode",
@@ -13,11 +20,10 @@ let package = Package(
     targets: [
         .target(
             name: "Punycode",
-            dependencies: [],
             path: "Sources"),
         .testTarget(
             name: "PunycodeSwiftTests",
             dependencies: ["Punycode"],
-            path: "Tests")
+            path: "Tests"),
     ]
 )

--- a/Punycode.podspec
+++ b/Punycode.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name                       = "Punycode"
-  s.version                    = "3.0.0"
+  s.version                    = "4.0.0"
   s.summary                    = "A Pure Swift library for encode and decode punycoded strings supporting iOS, macOS, tvOS, watchOS, and visionOS."
   s.homepage                   = "https://github.com/futamura/PunycodeSwift"
   s.license                    = { :type => "MIT", :file => "LICENSE" }

--- a/Punycode.xcodeproj/project.pbxproj
+++ b/Punycode.xcodeproj/project.pbxproj
@@ -405,10 +405,10 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 4.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.gumob.Punycode;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.Punycode;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -450,10 +450,10 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 3.0.0;
+				MARKETING_VERSION = 4.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.gumob.Punycode;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.Punycode;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -478,8 +478,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 3.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gumob.PunycodeTests;
+				MARKETING_VERSION = 4.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.PunycodeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
@@ -502,8 +502,8 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 3.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gumob.PunycodeTests;
+				MARKETING_VERSION = 4.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.PunycodeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";

--- a/Punycode.xcodeproj/project.pbxproj
+++ b/Punycode.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 				MARKETING_VERSION = 4.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.Punycode;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.futamura.Punycode;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -453,7 +453,7 @@
 				MARKETING_VERSION = 4.0.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.Punycode;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.futamura.Punycode;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -479,7 +479,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 4.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.PunycodeTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.futamura.PunycodeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
@@ -503,7 +503,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MARKETING_VERSION = 4.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.futamura.PunycodeTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.futamura.PunycodeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Punycode is a representation of Unicode with the limited ASCII character subset 
 - tvOS 12.0 or later
 - watchOS 4.0 or later
 - visionOS 1.0 or later
-- Swift 5.0 or later
+- Linux
+- Swift 5.9 or later (Xcode 15 or later) for Swift Package Manager
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange)](https://github.com/futamura/PunycodeSwift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/futamura/PunycodeSwift)
-[![Cocoapods Version](https://img.shields.io/cocoapods/v/Punycode.svg)](https://cocoapods.org/pods/Punycode)
-[![Cocoapods Platform](https://img.shields.io/cocoapods/p/Punycode.svg)](https://cocoadocs.org/docsets/Punycode)
 [![Build](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml/badge.svg)](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/futamura/PunycodeSwift/branch/main/graph/badge.svg)](https://codecov.io/gh/futamura/PunycodeSwift)
-![Language](https://img.shields.io/badge/Language-Swift%205.0-orange.svg)
+![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)
 ![License](https://img.shields.io/github/license/futamura/PunycodeSwift.svg)
 
 # PunycodeSwift

--- a/README.md
+++ b/README.md
@@ -115,7 +115,25 @@ sushi = sushi.idnaDecoded!
 print(sushi)  // "寿司"
 ```
 
+### Encode and decode the host of a URL:
+
+`idnaEncoded` expects a bare hostname. For a full URL, use `idnaEncodedURL` / `idnaDecodedURL`, which transform only the host and leave the scheme, userinfo, port, path, query, and fragment unchanged.
+
+```swift
+import Punycode
+
+var url: String = "http://www.ラーメン.寿司.co.jp/メニュー"
+
+url = url.idnaEncodedURL!
+print(url)  // http://www.xn--4dkp5a8a.xn--sprr0q.co.jp/メニュー
+
+url = url.idnaDecodedURL!
+print(url)  // http://www.ラーメン.寿司.co.jp/メニュー
+```
+
 ### Encode and decode Punycode directly:
+
+`punycodeEncoded` / `punycodeDecoded` are the raw RFC 3492 transformation of a single label: no `xn--` prefix is added and dots are not treated as label separators.
 
 ```swift
 import Punycode

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -4,11 +4,16 @@
 
 import Foundation
 
-/// This extension provides methods for encoding and decoding strings using Punycode (RFC 3492) 
-/// and IDNA encoding. It allows for the conversion of Substring instances to their Punycode 
+/// This extension provides methods for encoding and decoding strings using Punycode (RFC 3492)
+/// and IDNA encoding. It allows for the conversion of Substring instances to their Punycode
 /// and IDNA representations, facilitating the handling of internationalized domain names.
 public extension Substring {
     /// Returns new string in punycode encoding (RFC 3492)
+    ///
+    /// This is the raw RFC 3492 transformation of a single label: no `xn--`
+    /// prefix is added and dots are not treated as label separators, so
+    /// all-ASCII input yields a trailing delimiter (e.g. `"goo.gl"` becomes
+    /// `"goo.gl-"`). Use ``idnaEncoded`` to encode a hostname.
     ///
     /// - Returns: Punycode encoded string or nil if the string can't be encoded
     var punycodeEncoded: String? {
@@ -24,6 +29,10 @@ public extension Substring {
 
     /// Returns new string containing IDNA-encoded hostname
     ///
+    /// The hostname is mapped before encoding (NFKC compatibility folding,
+    /// lowercasing, NFC) and split on label separators, and only labels that
+    /// need it get the `xn--` ACE prefix.
+    ///
     /// - Returns: IDNA encoded hostname or nil if the string can't be encoded
     var idnaEncoded: String? {
         return Puny().encodeIDNA(self)
@@ -37,12 +46,17 @@ public extension Substring {
     }
 }
 
-/// This extension provides methods for encoding and decoding strings using Punycode (RFC 3492) 
-/// and IDNA encoding. It allows for the conversion of String instances to their Punycode 
+/// This extension provides methods for encoding and decoding strings using Punycode (RFC 3492)
+/// and IDNA encoding. It allows for the conversion of String instances to their Punycode
 /// and IDNA representations, facilitating the handling of internationalized domain names.
 public extension String {
 
     /// Returns new string in punycode encoding (RFC 3492)
+    ///
+    /// This is the raw RFC 3492 transformation of a single label: no `xn--`
+    /// prefix is added and dots are not treated as label separators, so
+    /// all-ASCII input yields a trailing delimiter (e.g. `"goo.gl"` becomes
+    /// `"goo.gl-"`). Use ``idnaEncoded`` to encode a hostname.
     ///
     /// - Returns: Punycode encoded string or nil if the string can't be encoded
     var punycodeEncoded: String? {
@@ -57,6 +71,10 @@ public extension String {
     }
 
     /// Returns new string containing IDNA-encoded hostname
+    ///
+    /// The hostname is mapped before encoding (NFKC compatibility folding,
+    /// lowercasing, NFC) and split on label separators, and only labels that
+    /// need it get the `xn--` ACE prefix.
     ///
     /// - Returns: IDNA encoded hostname or nil if the string can't be encoded
     var idnaEncoded: String? {

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -44,6 +44,28 @@ public extension Substring {
     var idnaDecoded: String? {
         return Puny().decodedIDNA(self)
     }
+
+    /// Returns new string with the host portion of a URL IDNA-encoded
+    ///
+    /// Unlike ``idnaEncoded``, which treats the whole string as a hostname,
+    /// this accepts a URL-shaped string and encodes only its host: scheme,
+    /// userinfo, port, path, query, and fragment are preserved unchanged.
+    ///
+    /// - Returns: The URL with its host IDNA-encoded, or nil if the host can't be encoded
+    var idnaEncodedURL: String? {
+        return Puny().encodeIDNAURL(self)
+    }
+
+    /// Returns new string with the host portion of a URL decoded from IDNA representation
+    ///
+    /// Unlike ``idnaDecoded``, which treats the whole string as a hostname,
+    /// this accepts a URL-shaped string and decodes only its host: scheme,
+    /// userinfo, port, path, query, and fragment are preserved unchanged.
+    ///
+    /// - Returns: The URL with its host decoded, or nil if the host doesn't contain correct encoding
+    var idnaDecodedURL: String? {
+        return Puny().decodedIDNAURL(self)
+    }
 }
 
 /// This extension provides methods for encoding and decoding strings using Punycode (RFC 3492)
@@ -86,5 +108,27 @@ public extension String {
     /// - Returns: Original hostname or nil if the string doesn't contain correct encoding
     var idnaDecoded: String? {
         return self[..<self.endIndex].idnaDecoded
+    }
+
+    /// Returns new string with the host portion of a URL IDNA-encoded
+    ///
+    /// Unlike ``idnaEncoded``, which treats the whole string as a hostname,
+    /// this accepts a URL-shaped string and encodes only its host: scheme,
+    /// userinfo, port, path, query, and fragment are preserved unchanged.
+    ///
+    /// - Returns: The URL with its host IDNA-encoded, or nil if the host can't be encoded
+    var idnaEncodedURL: String? {
+        return self[..<self.endIndex].idnaEncodedURL
+    }
+
+    /// Returns new string with the host portion of a URL decoded from IDNA representation
+    ///
+    /// Unlike ``idnaDecoded``, which treats the whole string as a hostname,
+    /// this accepts a URL-shaped string and decodes only its host: scheme,
+    /// userinfo, port, path, query, and fragment are preserved unchanged.
+    ///
+    /// - Returns: The URL with its host decoded, or nil if the host doesn't contain correct encoding
+    var idnaDecodedURL: String? {
+        return self[..<self.endIndex].idnaDecodedURL
     }
 }

--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Returns the last index of the specified element in the substring.
-/// 
+///
 /// - Parameter element: The character to search for.
 /// - Returns: The index of the last occurrence of the character, or nil if the character is not found.
 extension Substring {
@@ -21,13 +21,15 @@ extension Substring {
     }
 }
 
-/// A computed property that checks if the Unicode scalar is valid.
-/// 
+/// A computed property that checks if the Unicode scalar is acceptable in
+/// punycode-encoded text.
+///
 /// - Returns: A boolean value indicating whether the Unicode scalar is valid.
-///   A Unicode scalar is considered valid if its value is less than 0xD880 
-///   or within the range of 0xE000 to 0x1FFFFF.
+///   C1 control characters (U+0080...U+009F) never appear in legitimate
+///   punycode input or output; surrogates and out-of-range values are already
+///   unrepresentable in `Unicode.Scalar`.
 extension UnicodeScalar {
     internal var isValid: Bool {
-        return value < 0xD880 || (value >= 0xE000 && value <= 0x1FFFFF)
+        return !(0x80...0x9F).contains(value)
     }
 }

--- a/Sources/Punycode.swift
+++ b/Sources/Punycode.swift
@@ -293,4 +293,79 @@ public class Puny {
         }
         return output
     }
+
+    /// Returns a new string with the host portion of a URL-shaped string
+    /// IDNA-encoded. Scheme, userinfo, port, path, query, and fragment are
+    /// preserved unchanged.
+    ///
+    /// - Parameter input: The Substring containing a URL or a bare hostname.
+    /// - Returns: The string with its host IDNA-encoded, or nil if the host can't be encoded.
+    public func encodeIDNAURL(_ input: Substring) -> String? {
+        return transformURLHost(input) { encodeIDNA($0) }
+    }
+
+    /// Returns a new string with the host portion of a URL-shaped string
+    /// decoded from IDNA representation. Scheme, userinfo, port, path, query,
+    /// and fragment are preserved unchanged.
+    ///
+    /// - Parameter input: The Substring containing a URL or a bare hostname.
+    /// - Returns: The string with its host decoded, or nil if the host doesn't contain correct encoding.
+    public func decodedIDNAURL(_ input: Substring) -> String? {
+        return transformURLHost(input) { decodedIDNA($0) }
+    }
+
+    /// Locates the host portion of `[scheme://][userinfo@]host[:port][/path?query#fragment]`
+    /// and replaces it with the result of `transform`. IPv6 literals pass
+    /// through untransformed; an unterminated literal returns nil.
+    private func transformURLHost(_ input: Substring, using transform: (Substring) -> String?) -> String? {
+        /// Authority starts after "scheme://" or a protocol-relative "//"
+        var authorityStart: Substring.Index = input.startIndex
+        if let delimiterRange: Range<Substring.Index> = input.range(of: "://"),
+            isValidScheme(input[..<delimiterRange.lowerBound])
+        {
+            authorityStart = delimiterRange.upperBound
+        } else if input.hasPrefix("//") {
+            authorityStart = input.index(input.startIndex, offsetBy: 2)
+        }
+
+        /// Authority ends at the first path, query, or fragment delimiter
+        let authorityEnd: Substring.Index =
+            input[authorityStart...].firstIndex { $0 == "/" || $0 == "?" || $0 == "#" } ?? input.endIndex
+
+        /// The host follows the last "@" of the authority
+        let authority: Substring = input[authorityStart..<authorityEnd]
+        var hostStart: Substring.Index = authorityStart
+        if let atIndex: Substring.Index = authority.lastIndex(of: "@") {
+            hostStart = authority.index(after: atIndex)
+        }
+
+        let hostAndPort: Substring = input[hostStart..<authorityEnd]
+        if hostAndPort.hasPrefix("[") {
+            /// IPv6 literals are not IDNA-encoded
+            guard hostAndPort.contains("]") else {
+                return nil
+            }
+            return String(input)
+        }
+
+        /// The host ends where the port begins
+        let hostEnd: Substring.Index = hostAndPort.firstIndex(of: ":") ?? authorityEnd
+
+        guard let transformedHost: String = transform(input[hostStart..<hostEnd]) else {
+            return nil
+        }
+        return String(input[..<hostStart]) + transformedHost + String(input[hostEnd...])
+    }
+
+    /// A scheme is a letter followed by letters, digits, "+", "-", or "." (RFC 3986).
+    /// Anything else before "://" (for example a query string) is not a scheme.
+    private func isValidScheme(_ candidate: Substring) -> Bool {
+        guard let first: Character = candidate.first, first.isLetter, first.isASCII else {
+            return false
+        }
+        return candidate.allSatisfy { character in
+            (character.isASCII && (character.isLetter || character.isNumber))
+                || character == "+" || character == "-" || character == "."
+        }
+    }
 }

--- a/Sources/Punycode.swift
+++ b/Sources/Punycode.swift
@@ -128,8 +128,11 @@ public class Puny {
             var w: Int = 1
             var k: Int = base
             var sequenceComplete: Bool = false
-            repeat {
-                let character: Character = punycodeInput.removeFirst()
+            while !sequenceComplete {
+                /// The input must not end in the middle of a variable-length integer
+                guard let character: Character = punycodeInput.popFirst() else {
+                    return nil
+                }
                 guard let digit: Int = punycodeIndex(for: character) else {
                     return nil/// Failing on badly formatted punycode
                 }
@@ -143,17 +146,14 @@ public class Puny {
                 let t: Int = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias)
                 if digit < t {
                     sequenceComplete = true
-                    break
+                } else {
+                    let (nextW, nextWOverflow) = w.multipliedReportingOverflow(by: base - t)
+                    guard !nextWOverflow else {
+                        return nil
+                    }
+                    w = nextW
+                    k += base
                 }
-                let (nextW, nextWOverflow) = w.multipliedReportingOverflow(by: base - t)
-                guard !nextWOverflow else {
-                    return nil
-                }
-                w = nextW
-                k += base
-            } while !punycodeInput.isEmpty
-            guard sequenceComplete else {
-                return nil/// The input ended in the middle of a variable-length integer
             }
             bias = adaptBias(i - oldI, output.count + 1, oldI == 0)
             let (advancedN, advancedNOverflow) = n.addingReportingOverflow(i / (output.count + 1))

--- a/Sources/Punycode.swift
+++ b/Sources/Punycode.swift
@@ -127,23 +127,42 @@ public class Puny {
             let oldI: Int = i
             var w: Int = 1
             var k: Int = base
+            var sequenceComplete: Bool = false
             repeat {
                 let character: Character = punycodeInput.removeFirst()
                 guard let digit: Int = punycodeIndex(for: character) else {
                     return nil/// Failing on badly formatted punycode
                 }
-                i += digit * w
+                /// RFC 3492 section 6.4 requires overflow detection
+                let (weighted, weightedOverflow) = digit.multipliedReportingOverflow(by: w)
+                let (accumulated, accumulatedOverflow) = i.addingReportingOverflow(weighted)
+                guard !weightedOverflow, !accumulatedOverflow else {
+                    return nil
+                }
+                i = accumulated
                 let t: Int = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias)
                 if digit < t {
+                    sequenceComplete = true
                     break
                 }
-                w *= base - t
+                let (nextW, nextWOverflow) = w.multipliedReportingOverflow(by: base - t)
+                guard !nextWOverflow else {
+                    return nil
+                }
+                w = nextW
                 k += base
             } while !punycodeInput.isEmpty
+            guard sequenceComplete else {
+                return nil/// The input ended in the middle of a variable-length integer
+            }
             bias = adaptBias(i - oldI, output.count + 1, oldI == 0)
-            n += i / (output.count + 1)
+            let (advancedN, advancedNOverflow) = n.addingReportingOverflow(i / (output.count + 1))
+            guard !advancedNOverflow else {
+                return nil
+            }
+            n = advancedN
             i %= (output.count + 1)
-            guard n >= 0x80, let scalar: Unicode.Scalar = UnicodeScalar(n) else {
+            guard n >= 0x80, let scalar: Unicode.Scalar = UnicodeScalar(n), scalar.isValid else {
                 return nil
             }
             output.insert(Character(scalar), at: i)
@@ -182,7 +201,13 @@ public class Puny {
                     minimumCodepoint = Int(scalar.value)
                 }
             }
-            delta += (minimumCodepoint - n) * (handled + 1)
+            /// RFC 3492 section 6.3 requires overflow detection
+            let (stepped, steppedOverflow) = (minimumCodepoint - n).multipliedReportingOverflow(by: handled + 1)
+            let (advancedDelta, advancedDeltaOverflow) = delta.addingReportingOverflow(stepped)
+            guard !steppedOverflow, !advancedDeltaOverflow else {
+                return nil
+            }
+            delta = advancedDelta
             n = minimumCodepoint
             for scalar: Unicode.Scalar in input.unicodeScalars {
                 if scalar.value < n {
@@ -216,17 +241,28 @@ public class Puny {
 
     /// Returns new string containing IDNA-encoded hostname.
     ///
+    /// The input is mapped before encoding: compatibility decomposition (NFKC,
+    /// which folds full-width forms and alternate dot characters), lowercasing,
+    /// and canonical composition (NFC). This covers the common IDNA mapping
+    /// cases; the full UTS #46 mapping table is intentionally not implemented.
+    ///
     /// - Parameter input: The Substring to be encoded.
     /// - Returns: An IDNA encoded hostname or nil if the string can't be encoded.
     public func encodeIDNA(_ input: Substring) -> String? {
-        let parts: [Substring] = input.split(separator: ".")
+        /// The ideographic full stop survives NFKC, so it is mapped explicitly
+        let mapped: String = input
+            .precomposedStringWithCompatibilityMapping
+            .lowercased()
+            .precomposedStringWithCanonicalMapping
+            .replacingOccurrences(of: "\u{3002}", with: ".")
+        let parts: [Substring] = mapped.split(separator: ".")
         var output: String = ""
         for part: Substring in parts {
             if output.count > 0 {
                 output.append(".")
             }
             if part.rangeOfCharacter(from: CharacterSet.urlHostAllowed.inverted) != nil {
-                guard let encoded: String = part.lowercased().punycodeEncoded else { return nil }
+                guard let encoded: String = part.punycodeEncoded else { return nil }
                 output += ace + encoded
             } else {
                 output += part
@@ -246,8 +282,10 @@ public class Puny {
             if output.count > 0 {
                 output.append(".")
             }
-            if part.hasPrefix(ace) {
-                guard let decoded: String = part.dropFirst(ace.count).punycodeDecoded else { return nil }
+            /// The ACE prefix is case-insensitive (RFC 5890)
+            let lowercasedPart: String = part.lowercased()
+            if lowercasedPart.hasPrefix(ace) {
+                guard let decoded: String = lowercasedPart.dropFirst(ace.count).punycodeDecoded else { return nil }
                 output += decoded
             } else {
                 output += part

--- a/Tests/PunycodeTests.swift
+++ b/Tests/PunycodeTests.swift
@@ -205,6 +205,60 @@ final class PunycodeTests: XCTestCase {
         XCTAssertEqual("XN--BCHER-KVA.de".idnaDecoded, "bücher.de")
     }
 
+    /// idnaEncodedURL / idnaDecodedURL: only the host portion of a URL-shaped
+    /// string is transformed; scheme, userinfo, port, path, query, and
+    /// fragment pass through unchanged.
+
+    func testIDNAEncodedURL() {
+        XCTAssertEqual(
+            "http://www.ラーメン.寿司.co.jp".idnaEncodedURL,
+            "http://www.xn--4dkp5a8a.xn--sprr0q.co.jp"
+        )
+        XCTAssertEqual("https://test.com".idnaEncodedURL, "https://test.com")
+        XCTAssertEqual(
+            "http://ラーメン.jp/メニュー?q=寿司#上".idnaEncodedURL,
+            "http://xn--4dkp5a8a.jp/メニュー?q=寿司#上"
+        )
+        XCTAssertEqual("http://ラーメン.jp:8080/".idnaEncodedURL, "http://xn--4dkp5a8a.jp:8080/")
+        XCTAssertEqual("http://user@ラーメン.jp/".idnaEncodedURL, "http://user@xn--4dkp5a8a.jp/")
+        XCTAssertEqual("http://[::1]:8080/".idnaEncodedURL, "http://[::1]:8080/")
+        XCTAssertEqual("//ラーメン.jp/path".idnaEncodedURL, "//xn--4dkp5a8a.jp/path")
+        XCTAssertEqual("www.ラーメン.jp/path".idnaEncodedURL, "www.xn--4dkp5a8a.jp/path")
+        /// "://" inside the query must not be mistaken for a scheme delimiter
+        XCTAssertEqual(
+            "test.com/?u=http://ラーメン.jp".idnaEncodedURL,
+            "test.com/?u=http://ラーメン.jp"
+        )
+    }
+
+    func testIDNADecodedURL() {
+        XCTAssertEqual(
+            "http://www.xn--4dkp5a8a.xn--sprr0q.co.jp".idnaDecodedURL,
+            "http://www.ラーメン.寿司.co.jp"
+        )
+        XCTAssertEqual("http://xn--4dkp5a8a.jp:8080/x".idnaDecodedURL, "http://ラーメン.jp:8080/x")
+        XCTAssertEqual("http://user@xn--4dkp5a8a.jp/".idnaDecodedURL, "http://user@ラーメン.jp/")
+        XCTAssertEqual("http://[::1]/".idnaDecodedURL, "http://[::1]/")
+        XCTAssertEqual("https://test.com".idnaDecodedURL, "https://test.com")
+    }
+
+    func testIDNAURLRoundTrip() {
+        let url: String = "http://user@www.ラーメン.寿司.co.jp:8080/メニュー?q=寿司#上"
+        guard let encoded: String = url.idnaEncodedURL else {
+            return XCTFail("encoding failed")
+        }
+        XCTAssertEqual(encoded.idnaDecodedURL, url)
+    }
+
+    func testIDNAURLInvalidInputReturnsNil() {
+        /// Malformed punycode in the host
+        XCTAssertNil("http://xn--abcd.jp".idnaDecodedURL)
+        /// C1 control character in the host
+        XCTAssertNil("http://a\u{0085}b.jp".idnaEncodedURL)
+        /// Unterminated IPv6 literal
+        XCTAssertNil("http://[::1/".idnaEncodedURL)
+    }
+
     //    func testFoo1() {
     //        var sushi: String = "寿司"
     //

--- a/Tests/PunycodeTests.swift
+++ b/Tests/PunycodeTests.swift
@@ -130,6 +130,81 @@ final class PunycodeTests: XCTestCase {
         XCTAssertNoThrow(invalidPunycode.idnaDecoded)
     }
 
+    /// Issue #78: malformed punycode must decode to nil, never to garbage characters.
+
+    func testDecodingIncompleteDigitSequenceReturnsNil() {
+        /// RFC 3492: the input ends in the middle of a variable-length integer
+        XCTAssertNil("y".punycodeDecoded)
+        XCTAssertNil("y-z".punycodeDecoded)
+        XCTAssertNil("a-b-c-d".punycodeDecoded)
+    }
+
+    func testDecodingC1ControlCharactersReturnsNil() {
+        /// "abcd" decodes to U+0080-range C1 control characters, which never
+        /// appear in legitimate text
+        XCTAssertNil("abcd".punycodeDecoded)
+    }
+
+    func testDecodingInvalidDigitsReturnsNil() {
+        XCTAssertNil("-".punycodeDecoded)
+        XCTAssertNil("аб".punycodeDecoded)
+    }
+
+    func testDecodingOverflowReturnsNilInsteadOfTrapping() {
+        /// RFC 3492 section 6.4 requires overflow detection; unchecked
+        /// arithmetic would trap on inputs like these ('9' is the highest
+        /// digit value, so the weight keeps multiplying without a break)
+        XCTAssertNil(String(repeating: "9", count: 30).punycodeDecoded)
+        XCTAssertNil(String(repeating: "z", count: 64).punycodeDecoded)
+    }
+
+    func testDecodingValidEdgeCases() {
+        /// RFC 3492: all-ASCII input encodes to "<input>-", so these round-trip
+        XCTAssertEqual("-".punycodeEncoded, "--")
+        XCTAssertEqual("--".punycodeDecoded, "-")
+        XCTAssertEqual("y".punycodeEncoded, "y-")
+        XCTAssertEqual("y-".punycodeDecoded, "y")
+        /// Valid samples from the issue #78 report
+        XCTAssertEqual("90a".punycodeDecoded, "б")
+        XCTAssertEqual("--9sb".punycodeDecoded, "б-")
+        XCTAssertEqual("--btb".punycodeDecoded, "-б")
+        XCTAssertEqual("80acde".punycodeDecoded, "абвг")
+        XCTAssertEqual("abcd-u8d".punycodeDecoded, "ёabcd")
+        XCTAssertEqual("abcd-y8d".punycodeDecoded, "abcdё")
+        XCTAssertEqual("a-b-c-d-lng".punycodeDecoded, "ёa-b-c-d")
+        XCTAssertEqual("-a-b-c-d-vbhklm5q".punycodeDecoded, "ёпрст-a-b-c-d")
+        XCTAssertEqual("a-b-c-d--3bhklm5q".punycodeDecoded, "a-b-c-d-ёпрст")
+        XCTAssertEqual("bcher-kva".punycodeDecoded, "bücher")
+        XCTAssertEqual("80abnmycp7evc".punycodeDecoded, "обращения")
+        XCTAssertEqual("r1aadaaghijkl".punycodeDecoded, "ттуууфхцчшщ")
+    }
+
+    /// Issue #4: punycodeEncoded is raw RFC 3492 (single label, no ACE prefix);
+    /// idnaEncoded is for hostnames.
+
+    func testPunycodeEncodedIsRawRFC3492() {
+        XCTAssertEqual("goo.gl".punycodeEncoded, "goo.gl-")
+        XCTAssertEqual("goo.gl".idnaEncoded, "goo.gl")
+        XCTAssertEqual("example.com".idnaEncoded, "example.com")
+    }
+
+    func testIDNAEncodingAppliesUnicodeMapping() {
+        /// Full-width forms, alternate dots, and case are mapped before encoding
+        XCTAssertEqual("ＧＯＯ．ＧＬ".idnaEncoded, "goo.gl")
+        XCTAssertEqual("example。com".idnaEncoded, "example.com")
+        XCTAssertEqual("example｡com".idnaEncoded, "example.com")
+        XCTAssertEqual("EXAMPLE.COM".idnaEncoded, "example.com")
+        XCTAssertEqual("日本語。ＪＰ".idnaEncoded, "xn--wgv71a119e.jp")
+        /// NFC: the decomposed form (u + combining diaeresis) encodes
+        /// identically to the composed form
+        XCTAssertEqual("bu\u{0308}cher.de".idnaEncoded, "xn--bcher-kva.de")
+        XCTAssertEqual("bücher.de".idnaEncoded, "xn--bcher-kva.de")
+    }
+
+    func testIDNADecodingAcceptsUppercaseACEPrefix() {
+        XCTAssertEqual("XN--BCHER-KVA.de".idnaDecoded, "bücher.de")
+    }
+
     //    func testFoo1() {
     //        var sushi: String = "寿司"
     //

--- a/Tests/PunycodeTests.swift
+++ b/Tests/PunycodeTests.swift
@@ -224,6 +224,9 @@ final class PunycodeTests: XCTestCase {
         XCTAssertEqual("http://[::1]:8080/".idnaEncodedURL, "http://[::1]:8080/")
         XCTAssertEqual("//ラーメン.jp/path".idnaEncodedURL, "//xn--4dkp5a8a.jp/path")
         XCTAssertEqual("www.ラーメン.jp/path".idnaEncodedURL, "www.xn--4dkp5a8a.jp/path")
+        /// Invalid schemes are not treated as scheme delimiters
+        XCTAssertEqual("1a://ラーメン.jp/x".idnaEncodedURL, "1a://ラーメン.jp/x")
+        XCTAssertEqual("://test.com".idnaEncodedURL, "://test.com")
         /// "://" inside the query must not be mistaken for a scheme delimiter
         XCTAssertEqual(
             "test.com/?u=http://ラーメン.jp".idnaEncodedURL,

--- a/scripts/gen_docs.sh
+++ b/scripts/gen_docs.sh
@@ -28,7 +28,7 @@ swift symbolgraph-extract \
 
 xcrun docc convert \
   --fallback-display-name Punycode \
-  --fallback-bundle-identifier com.futamura.Punycode \
+  --fallback-bundle-identifier dev.futamura.Punycode \
   --fallback-bundle-version "${version}" \
   --additional-symbol-graph-dir .build/symbol-graphs \
   --transform-for-static-hosting \


### PR DESCRIPTION
## Summary

Everything staged for the 4.0.0 release:

- **Breaking — manifest**: `Package.swift` requires swift-tools 5.9 (Xcode 15+ for SPM consumers) and declares explicit platforms (deployment targets unchanged: macOS 10.13, iOS 12, tvOS 12, watchOS 4, visionOS 1).
- **Linux support**: verified by a new `SPM: Linux, Swift 6.2` CI job on the official Swift container, part of the CI Success gate.
- **Decode hardening** (#78): malformed punycode (mid-sequence truncation, C1 control output) now returns nil instead of garbage; RFC 3492 overflow checks implemented with checked arithmetic — adversarial inputs return nil instead of trapping.
- **IDNA mapping** (#4, breaking): `idnaEncoded` maps input first (NFKC folding, lowercasing, NFC, ideographic full stop); `idnaDecoded` accepts uppercase ACE prefixes; `punycodeEncoded` documented as the raw RFC 3492 single-label transform.
- **New API**: `idnaEncodedURL` / `idnaDecodedURL` transform only the host of a URL-shaped string (motivated by futamura/TLDExtractSwift#8).
- **Identity**: bundle IDs renamed to `dev.futamura.*`; version bumped to 4.0.0; CocoaPods badges dropped from the README.

Merging closes #78 and #4.

## Release plan

After merge: push the `4.0.0` tag — `release.yml` verifies it against `MARKETING_VERSION`, creates the GitHub Release from the changelog section, and pushes to CocoaPods trunk.

## Test plan

- [ ] CI Success gate passes (including the Linux job)
- [ ] After tagging: Release workflow creates the GitHub Release and the pod push succeeds