### PR TITLE
Make fastlane version lanes usable without a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Maintainer tooling: the `set_version` / `bump_version` fastlane lanes accept `version:` / `type:` arguments and fail loudly without a TTY, instead of reporting success while leaving the version unchanged. Version strings are now validated against an anchored pattern, so malformed input such as `1a2b3` is rejected rather than written to the project.
+
 ## [4.0.1] - 2026-08-18
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ bundle exec fastlane gen_docs         # DocC static site into docc-site/ (via sc
 bundle exec fastlane set_version      # prompt for version; sets MARKETING_VERSION in the pbxproj
 bundle exec fastlane bump_version     # patch/minor/major bump; same effect
 
+# Same lanes without a TTY (agents, scripts) — the argument is required there
+bundle exec fastlane set_version version:4.0.2
+bundle exec fastlane bump_version type:patch
+
 # Interactive job menu (fzf)
 ./run.sh
 ```
@@ -50,7 +54,7 @@ Tests live in `Tests/PunycodeTests.swift` (single XCTest file; SPM test target n
 
 ## Versioning and release
 
-- Single source of truth for the version: `MARKETING_VERSION` in `Punycode.xcodeproj/project.pbxproj`. Fastlane and CI both read it. Never edit versions by hand — use `fastlane set_version` / `bump_version`.
+- Single source of truth for the version: `MARKETING_VERSION` in `Punycode.xcodeproj/project.pbxproj`. Fastlane and CI both read it. Never edit versions by hand — use `fastlane set_version` / `bump_version`. Both lanes prompt only when stdin is a TTY; without one, pass `version:` / `type:` or the lane fails rather than silently leaving the version untouched.
 - Branch flow: work on `develop`, PR into `main`.
 - CI (`.github/workflows/main.yml`) runs on push and pull request to `main`/`develop`: lint → per-platform xcodebuild tests (simulator devices resolved at runtime via `simctl`) → SPM (macOS + Linux via the official Swift container). It does not release. Carthage builds are not CI-verified.
 - The only required branch-protection check is `CI Success`. Codecov statuses are informational: `codecov.yml` gives the project status a 1% threshold, but the patch status targets the auto baseline and may fail on PRs whose new lines are defensive/unreachable guards — that does not block merging.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,26 +27,37 @@ end
 ##########################################
 
 desc "Set version number"
-lane :set_version do
+lane :set_version do |options|
     current_app_version = get_version_number_from_xcodeproj(xcodeproj: xcodeproj_file)
-    new_app_version = prompt(
-        text: "Please enter version number (Current: #{current_app_version}): ",
-        ci_input: current_app_version
-    )
-    regexp = Regexp.new("[0-9]+\.[0-9]+\.[0-9]+")
-    matched = regexp.match(new_app_version)
-    if matched then
-        # Set version number to project
-        increment_version_number_in_xcodeproj(version_number: new_app_version)
-        UI.message("Changed version from #{current_app_version} to #{new_app_version} ")
-    else
-        UI.error("Invalid version number. #{new_app_version}")
+    new_app_version = options[:version]&.to_s
+    if new_app_version.nil? then
+        unless UI.interactive? then
+            UI.user_error!("No TTY to prompt on. Pass the version instead: fastlane set_version version:#{current_app_version}")
+        end
+        new_app_version = UI.input("Please enter version number (Current: #{current_app_version}): ")
     end
+    # Anchored so that partial matches such as "1a2b3" are rejected
+    unless new_app_version.match?(/\A\d+\.\d+\.\d+\z/) then
+        UI.user_error!("Invalid version number. #{new_app_version}")
+    end
+    # Set version number to project
+    increment_version_number_in_xcodeproj(version_number: new_app_version)
+    UI.message("Changed version from #{current_app_version} to #{new_app_version} ")
 end
 
 desc "Bump version number"
-lane :bump_version do
-    bump_type = UI.select("Select version position to be upgraded: ", ["patch", "minor", "major"])
+lane :bump_version do |options|
+    bump_types = ["patch", "minor", "major"]
+    bump_type = options[:type]&.to_s
+    if bump_type.nil? then
+        unless UI.interactive? then
+            UI.user_error!("No TTY to prompt on. Pass the bump type instead: fastlane bump_version type:patch")
+        end
+        bump_type = UI.select("Select version position to be upgraded: ", bump_types)
+    end
+    unless bump_types.include?(bump_type) then
+        UI.user_error!("Invalid bump type. #{bump_type} (expected one of: #{bump_types.join(", ")})")
+    end
     current_app_version = get_version_number_from_xcodeproj(xcodeproj: xcodeproj_file)
     current_app_versions = current_app_version.split(".")
     current_app_version_patch = current_app_versions[2].to_i


### PR DESCRIPTION
## Summary

Two defects in the `set_version` / `bump_version` lanes, both of which could silently ship a wrong version:

- **Silent no-op without a TTY.** `set_version` used `prompt(..., ci_input: current_app_version)`, so a piped stdin took the `ci_input` branch: the lane logged `Changed version from 4.0.0 to 4.0.0` and exited 0 having changed nothing. `bump_version` used `UI.select` and had no non-interactive path at all. Both lanes now accept an argument (`version:` / `type:`) and call `UI.user_error!` when there is no TTY and none was given.
- **Broken version validation.** The pattern came from `Regexp.new("[0-9]+\.[0-9]+\.[0-9]+")`; Ruby drops the backslash in a double-quoted string, so `\.` became `.` (any character) and the match was unanchored. Verified: `1a2b3`, `junk9.9.9junk`, and `v4.0.2-beta` all validated and would have been written into the project. Now `/\A\d+\.\d+\.\d+\z/`, and invalid input raises instead of only logging.

The interactive path used by `./run.sh` is unchanged.

## Test plan

Ran against the working tree, restoring `project.pbxproj` after each run:

- [x] `fastlane set_version version:4.0.2` (non-TTY) → `Changed version from 4.0.1 to 4.0.2`, and `MARKETING_VERSION` really became 4.0.2
- [x] `fastlane set_version < /dev/null` → exit 1, "No TTY to prompt on. Pass the version instead: …"
- [x] `fastlane set_version version:1a2b3` → exit 1, "Invalid version number. 1a2b3"
- [x] `fastlane bump_version type:patch` (non-TTY) → `Changed version from 4.0.1 to 4.0.2`
- [x] `fastlane bump_version type:pathc` → exit 1, "Invalid bump type. pathc (expected one of: patch, minor, major)"
- [x] Both lanes under a pseudo-TTY → prompt / select behave as before
- [ ] CI Success gate passes

`MARKETING_VERSION` is left at 4.0.1 by this branch. `fastlane/README.md` needs no update — no lane description changed.

The same fix is being applied to futamura/TLDExtractSwift, whose Fastfile carries identical lanes.