### PR TITLE
Drop dead PSL menu entry from run.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- The dead "Public Suffix List" entry in the `./run.sh` menu, left over from TLDExtractSwift's copy of the script; it called an `update-psl.py` that does not exist in this repository.
+
 ### Fixed
 
 - Maintainer tooling: the `set_version` / `bump_version` fastlane lanes accept `version:` / `type:` arguments and fail loudly without a TTY, instead of reporting success while leaving the version unchanged. Version strings are now validated against an anchored pattern, so malformed input such as `1a2b3` is rejected rather than written to the project.

--- a/run.sh
+++ b/run.sh
@@ -23,8 +23,6 @@ local option_list=(
 	" "
 	"Github - Update tag"
 	"Github - Fetch remote tag"
-	" "
-	"Public Suffix List - Download latest data"
 )
 
 local fastlane_command() {
@@ -43,7 +41,6 @@ local xcode_init() {
 	xcode_clean;
 	# rm -rf ./Carthage/*;
 	# carthage_update;
-	# psl_download;
 }
 
 local carthage_update() {
@@ -88,10 +85,6 @@ local github_fetch_remote_tag() {
     git fetch --tags --force;
 }
 
-local psl_download() {
-    python update-psl.py;
-}
-
 local bundle_init() {
     rm -rf .bundle;
 	rm -rf Gemfile.lock;
@@ -109,7 +102,6 @@ case "$selected_option" in
 	"Carthage - Update all platforms")           carthage_update;;
 	"Github - Update tag")                       github_update_tag;;
 	"Github - Fetch remote tag")                 github_fetch_remote_tag;;
-	"Public Suffix List - Download latest data") psl_download;;
 	*)                                           echo "Invalid option $selected_option" && exit 1;;
 esac
 


### PR DESCRIPTION
## Summary

- Remove the "Public Suffix List - Download latest data" entry from the `./run.sh` fzf menu, along with the `psl_download()` function, its dispatch case, and a commented-out call. All of it was left over from TLDExtractSwift's copy of the script and invoked an `update-psl.py` that does not exist in this repository, so selecting the entry failed at runtime.

Verified locally: `zsh -n run.sh` passes and no PSL references remain. Surfaced by a cross-repo consistency check against TLDExtractSwift; the counterpart finding there (stale `Package.resolved` pin) is fixed on that repo's develop.

## Test plan

- [ ] CI Success gate passes