### PR TITLE
chore: prepare Swift Package Index listing

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,10 +1,14 @@
 # Swift Package Index build configuration.
 # https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases
 #
-# documentation_targets makes SPI build and host the DocC documentation for the
-# package. This is independent of the GitHub Pages site built by
-# scripts/gen_docs.sh; both stay available.
+# SPI builds and hosts the DocC documentation for the Punycode target. The
+# whole public API lives in extensions on String/Substring, so the build needs
+# --include-extended-types; without it the generated site is almost empty.
+# This mirrors the -emit-extension-block-symbols flag in scripts/gen_docs.sh,
+# which builds the GitHub Pages site. Both documentation locations stay
+# available.
 version: 1
 builder:
   configs:
     - documentation_targets: [Punycode]
+      custom_documentation_parameters: [--include-extended-types]

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,10 @@
+# Swift Package Index build configuration.
+# https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases
+#
+# documentation_targets makes SPI build and host the DocC documentation for the
+# package. This is independent of the GitHub Pages site built by
+# scripts/gen_docs.sh; both stay available.
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Punycode]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site. The README gains the SPI Swift version and platform compatibility badges.
+
 ### Removed
 
 - The dead "Public Suffix List" entry in the `./run.sh` menu, left over from TLDExtractSwift's copy of the script; it called an `update-psl.py` that does not exist in this repository.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift_Package_Manager-compatible-orange)](https://github.com/futamura/PunycodeSwift)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/futamura/PunycodeSwift)
+[![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FPunycodeSwift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/futamura/PunycodeSwift)
+[![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FPunycodeSwift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/futamura/PunycodeSwift)
 [![Build](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml/badge.svg)](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/futamura/PunycodeSwift/branch/main/graph/badge.svg)](https://codecov.io/gh/futamura/PunycodeSwift)
 ![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)


### PR DESCRIPTION
## Summary

Prepares the repository for a Swift Package Index (SPI) listing.

- `.spi.yml`: declares `documentation_targets: [Punycode]` so the SPI builder generates and hosts the DocC documentation for the package, plus `custom_documentation_parameters: [--include-extended-types]`. The whole public API lives in extensions on `String`/`Substring`, so without that flag the site SPI hosts would be almost empty — it is the swift-docc-plugin equivalent of the `-emit-extension-block-symbols` flag `scripts/gen_docs.sh` passes to `symbolgraph-extract`. The GitHub Pages site is unaffected; both documentation locations stay available.
- `README.md`: adds the SPI Swift version and platform compatibility badges.
- `CHANGELOG.md`: entry under **Unreleased**.

## Notes

The two new badges render as "unknown" until the package is accepted into the [PackageList](https://github.com/SwiftPackageIndex/PackageList) and SPI has run its first build. Submission is a separate step, done after this merges, and is bundled with TLDExtractSwift in a single PackageList issue.

Once SPI has built the documentation, check that the hosted site is not empty. If it is, fall back to pointing `external_links.documentation` at the GitHub Pages site instead.

## Test plan

- `swift package dump-package` succeeds (manifest unchanged by this PR).
- `.spi.yml` parses as valid YAML, matches the SPIManifest shape (`version` + `builder.configs[].documentation_targets` + `custom_documentation_parameters`), and is 677 bytes, under SPIManifest's 1500 byte limit.
- No source changes, so CI is the usual lint + per-platform tests.