### PR TITLE
chore: set the SPI author line

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -8,6 +8,10 @@
 # which builds the GitHub Pages site. Both documentation locations stay
 # available.
 version: 1
+# Overrides the author line SPI derives from the commit history, which still
+# credits the repository's former `gumob` handle.
+metadata:
+  authors: Kojiro Futamura and contributors
 builder:
   configs:
     - documentation_targets: [Punycode]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site. The README gains the SPI Swift version and platform compatibility badges.
+- Swift Package Index listing, with an `.spi.yml` that has SPI build and host the DocC documentation alongside the GitHub Pages site and sets the author line shown on the package page. The README gains the SPI Swift version and platform compatibility badges.
 
 ### Removed
 


### PR DESCRIPTION
## Summary

The Swift Package Index page currently reads "Written by gumob and 6 other contributors." — SPI derives that line from the commit history, which still carries the repository's former `gumob` handle.

- `.spi.yml`: adds `metadata.authors: Kojiro Futamura and contributors`, so the page reads "Written by Kojiro Futamura and contributors." instead. The phrasing deliberately avoids a contributor count, which would go stale.
- `CHANGELOG.md`: extends the existing **Unreleased** entry rather than adding a second one.

## Test plan

- `.spi.yml` parses as valid YAML and matches the SPIManifest shape (`metadata.authors` is a plain string); the file is 858 bytes, under SPIManifest's 1500 byte limit.
- No source changes, so CI is the usual lint + per-platform tests.
- The author line updates the next time SPI reprocesses the default branch.