### PR TITLE
fix: make the SPI author line a full sentence

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -9,9 +9,11 @@
 # available.
 version: 1
 # Overrides the author line SPI derives from the commit history, which still
-# credits the repository's former `gumob` handle.
+# credits the repository's former `gumob` handle. SPI renders this value
+# verbatim -- unlike the derived line, it gets no "Written by" prefix and no
+# full stop -- so the value has to be a complete sentence.
 metadata:
-  authors: Kojiro Futamura and contributors
+  authors: Written by Kojiro Futamura and contributors.
 builder:
   configs:
     - documentation_targets: [Punycode]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The author line on the Swift Package Index page reads as a sentence again. SPI renders `metadata.authors` from `.spi.yml` verbatim, without the "Written by" prefix and full stop it adds to the line it derives from the commit history, so the value now carries them itself.
+
 ## [4.0.2] - 2026-08-21
 
 ### Added


### PR DESCRIPTION
## Summary

`metadata.authors` in `.spi.yml` was set to `Kojiro Futamura and contributors` in #89. Reading the Swift Package Index server source shows that value would have rendered as a bare fragment.

`Sources/App/Views/PackageController/GetRoute.Model+ext.swift` adds the `Written by ` prefix and the full stop **only** to the line it derives from the commit history:

```swift
case .fromSPIManifest(var spiymlAuthors):
    if spiymlAuthors.count > 200 { spiymlAuthors = String(spiymlAuthors.prefix(200)) + "&hellip;" }
    return .li(.class("authors"), .text(spiymlAuthors))

case .fromGitRepository(let repositoryAuthors):
    ... listPhrase(opening: "Written by ", nodes: nodes, closing: ".")
```

So the value has to be a complete sentence. It now reads `Written by Kojiro Futamura and contributors.`, and the comment above it records why. TLDExtractSwift carries the same change.

The page still shows the old derived line, so this lands before the first render rather than correcting it afterwards.

## Notes

`Sources/App/Controllers/API/API+PackageController+PackageResult.swift` reads the manifest from `defaultBranchVersion` only — a release does not carry the author line forward, which is why 4.0.2 updated the "Latest Release" field but left the author line untouched. SPI's own docs put default-branch `.spi.yml` changes at up to 24 hours.

## Test plan

- `.spi.yml` parses as valid YAML; `metadata.authors` is `Written by Kojiro Futamura and contributors.` and the file is 1029 bytes, under SPIManifest's 1500 byte limit and the 200 character cap on the authors string.
- No source changes, so CI is the usual lint + per-platform tests.