### PR TITLE
chore: drop the hardcoded Swift version badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- The hardcoded "Language: Swift 5.9" README badge. It duplicated the Swift Package Index Swift version badge, which reports the versions the package actually builds against instead of a number kept up to date by hand.
+
 ### Fixed
 
 - The author line on the Swift Package Index page reads as a sentence again. SPI renders `metadata.authors` from `.spi.yml` verbatim, without the "Written by" prefix and full stop it adds to the line it derives from the commit history, so the value now carries them itself.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Ffutamura%2FPunycodeSwift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/futamura/PunycodeSwift)
 [![Build](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml/badge.svg)](https://github.com/futamura/PunycodeSwift/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/futamura/PunycodeSwift/branch/main/graph/badge.svg)](https://codecov.io/gh/futamura/PunycodeSwift)
-![Language](https://img.shields.io/badge/Language-Swift%205.9-orange.svg)
 ![License](https://img.shields.io/github/license/futamura/PunycodeSwift.svg)
 
 # PunycodeSwift


### PR DESCRIPTION
## Summary

The README carried a static `Language: Swift 5.9` badge alongside the Swift Package Index Swift version badge added in 4.0.2. The SPI badge reports the versions the package actually builds against — currently `6.3 | 6.2 | 6.1 | 6.0` — so the hardcoded one was both redundant and out of date.

- `README.md`: removes the `Language` badge line. The remaining badges are SPM, Carthage, SPI Swift versions, SPI platforms, Build, codecov, and License.
- `CHANGELOG.md`: entry under **Unreleased**.

TLDExtractSwift carries the same badge and drops it too.

## Test plan

- No source or manifest changes; CI is the usual lint + per-platform tests.